### PR TITLE
feat: Add ChatGPT Connector integration with configurable search

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,28 +126,25 @@ If you prefer to configure Claude Desktop directly instead of using Connectors, 
 Replace `<account_subdomain>` with your actual Cloudflare Workers subdomain in all examples.
 
 #### ChatGPT Integration
-This MCP server provides dedicated ChatGPT endpoints with optimized search/fetch tools:
 
-1. **Import as ChatGPT Connector**:
-   - In ChatGPT, go to Settings → Connectors
-   - Add a new connector using the ChatGPT-specific Streamable HTTP endpoint:
-     ```
-     https://obvec.<account_subdomain>.workers.dev/chatgpt/mcp
-     ```
-   - The server provides exactly the `search` and `fetch` tools ChatGPT requires
-   - Set `OBSIDIAN_VAULT_NAME` in your wrangler.toml for proper Obsidian URLs
+Connect your Obsidian vault to ChatGPT as a searchable knowledge source:
 
-2. **Clean Separation**:
-   - ChatGPT uses `/chatgpt/mcp` (Streamable HTTP) or `/chatgpt/sse` (SSE) endpoints with only search/fetch tools
-   - Standard MCP clients use `/mcp` (Streamable HTTP) or `/sse` (SSE) endpoints with full Obsidian tools
-   - No tool confusion or conflicts between different client types
+1. **Add as ChatGPT Connector**:
+   - Go to ChatGPT Settings → Connectors
+   - Add connector with URL: `https://obvec.<account_subdomain>.workers.dev/chatgpt/mcp`
+   - Authenticate via OAuth when prompted
+   - Select the connector in any chat where Connectors are supported
 
-3. **Use with Deep Research**:
-   - ChatGPT can use this connector for deep research tasks
-   - Your Obsidian notes become searchable knowledge for research
-   - Supports both chat connectors and API-based deep research
+2. **Basic Configuration**:
+   ```toml
+   # In wrangler.toml
+   OBSIDIAN_VAULT_NAME = "YourVaultName"  # For proper Obsidian URL generation
+   CHATGPT_MIN_SCORE = "0.3"              # Result threshold (lower = more results)
+   ```
 
-**Architecture Note**: The server uses separate Durable Objects for standard MCP and ChatGPT endpoints, ensuring complete isolation and optimal performance for each use case.
+3. **Works with all ChatGPT features** where Connectors are available (except GPT-5 Pro mode)
+
+📚 **For advanced configuration, QDF support, and troubleshooting, see [docs/chatgpt-integration.md](docs/chatgpt-integration.md)**
 
 ## 🔐 Authentication & Security
 
@@ -288,6 +285,7 @@ For advanced features like smart re-indexing, timestamp queries, custom embeddin
 ## 📚 Documentation
 
 For detailed guides, see:
+- **[ChatGPT Integration](docs/chatgpt-integration.md)** - ChatGPT connector setup and configuration
 - **[Architecture](docs/architecture.md)** - Technical implementation details
 - **[Advanced Configuration](docs/advanced-configuration.md)** - Power user features
 - **[Pricing & Performance](docs/pricing-and-performance.md)** - Cost analysis and limits

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ On [claude.ai](https://claude.ai), add a custom MCP Connector:
 2. Click "Add Custom Connector"
 3. Enter your MCP endpoint:
    - **Streamable HTTP**: `https://obvec.<account_subdomain>.workers.dev/mcp` (recommended - current MCP spec)
-   - **SSE**: `https://obvec.<account_subdomain>.workers.dev/sse` (deprecated - for backward compatibility)
+   - **SSE**: `https://obvec.<account_subdomain>.workers.dev/sse` (deprecated - only use if required)
 
 **Note**: The MCP specification deprecated SSE on March 26, 2025. We recommend using the Streamable HTTP endpoint.
 
@@ -124,6 +124,30 @@ If you prefer to configure Claude Desktop directly instead of using Connectors, 
 ```
 
 Replace `<account_subdomain>` with your actual Cloudflare Workers subdomain in all examples.
+
+#### ChatGPT Integration
+This MCP server provides dedicated ChatGPT endpoints with optimized search/fetch tools:
+
+1. **Import as ChatGPT Connector**:
+   - In ChatGPT, go to Settings → Connectors
+   - Add a new connector using the ChatGPT-specific Streamable HTTP endpoint:
+     ```
+     https://obvec.<account_subdomain>.workers.dev/chatgpt/mcp
+     ```
+   - The server provides exactly the `search` and `fetch` tools ChatGPT requires
+   - Set `OBSIDIAN_VAULT_NAME` in your wrangler.toml for proper Obsidian URLs
+
+2. **Clean Separation**:
+   - ChatGPT uses `/chatgpt/mcp` (Streamable HTTP) or `/chatgpt/sse` (SSE) endpoints with only search/fetch tools
+   - Standard MCP clients use `/mcp` (Streamable HTTP) or `/sse` (SSE) endpoints with full Obsidian tools
+   - No tool confusion or conflicts between different client types
+
+3. **Use with Deep Research**:
+   - ChatGPT can use this connector for deep research tasks
+   - Your Obsidian notes become searchable knowledge for research
+   - Supports both chat connectors and API-based deep research
+
+**Architecture Note**: The server uses separate Durable Objects for standard MCP and ChatGPT endpoints, ensuring complete isolation and optimal performance for each use case.
 
 ## 🔐 Authentication & Security
 
@@ -160,9 +184,27 @@ obvec/
 │   └── cleanup-orphaned.ts          # Remove deleted notes
 ├── src/
 │   ├── api/                         # API endpoints
+│   │   ├── cleanup.ts               # Cleanup orphaned notes
+│   │   ├── index.ts                 # Index management
+│   │   ├── list-indexed.ts          # List indexed notes
+│   │   ├── router.ts                # API router
+│   │   ├── search.ts                # Search functionality
+│   │   ├── stats.ts                 # Statistics endpoint
+│   │   └── test-mcp.ts              # MCP testing utilities
 │   ├── auth/                        # Authentication UI
-│   ├── mcp/                         # MCP server implementation
+│   │   └── app.ts                   # OAuth app handler
+│   ├── mcp/                         # MCP server implementations
+│   │   ├── server.ts                # Standard MCP server (full tools)
+│   │   └── server-chatgpt.ts        # ChatGPT-specific server (search/fetch only)
 │   ├── types/                       # TypeScript types
+│   │   └── index.ts                 # Type definitions
+│   ├── utils/                       # Utility functions
+│   │   ├── auth.ts                  # Authentication utilities
+│   │   ├── embeddings.ts            # Embedding generation
+│   │   ├── formatting.ts            # Text formatting
+│   │   ├── hash.ts                  # Hashing utilities
+│   │   ├── security.ts              # Security utilities
+│   │   └── validation.ts            # Input validation
 │   └── index.ts                     # Main Worker entry
 ├── .env.example                     # Environment variables template
 ├── .gitignore                       # Git ignore patterns

--- a/docs/chatgpt-integration.md
+++ b/docs/chatgpt-integration.md
@@ -1,0 +1,248 @@
+# ChatGPT Integration Guide
+
+This guide covers the ChatGPT-specific MCP server implementation, configuration options, and advanced features.
+
+## Overview
+
+The ChatGPT integration provides a dedicated MCP server endpoint optimized for ChatGPT's connector interface. Unlike standard MCP clients, ChatGPT requires specific tool names (`search` and `fetch`) with simplified parameters.
+
+## Quick Setup
+
+1. Add the connector in ChatGPT Settings → Connectors:
+   ```
+   https://obvec.<account_subdomain>.workers.dev/chatgpt/mcp
+   ```
+
+2. Authenticate via OAuth when prompted
+
+3. Select the connector in any chat where Connectors are supported
+
+## Architecture
+
+### Separate Durable Objects
+
+The implementation uses two distinct Durable Objects:
+- `ObsidianVectorizeMCP`: Standard MCP server with full Obsidian tools
+- `ChatGPTMCP`: Simplified server with only search/fetch tools
+
+This separation ensures:
+- No tool confusion between different client types
+- Optimal performance for each use case
+- Clean API boundaries
+
+### Endpoint Routing
+
+- `/mcp` and `/sse` → Standard MCP server
+- `/chatgpt/mcp` and `/chatgpt/sse` → ChatGPT-specific server
+
+## Configuration
+
+All ChatGPT-specific settings are configured via environment variables in `wrangler.toml`:
+
+### CHATGPT_MIN_SCORE
+
+Controls the minimum similarity score for search results.
+
+```toml
+CHATGPT_MIN_SCORE = "0.3"  # Default: 0.3, Range: 0.0-1.0
+```
+
+- **Lower values (0.2-0.3)**: Return more results, let ChatGPT filter
+- **Higher values (0.5-0.7)**: Only high-confidence matches
+- **Recommendation**: Keep at 0.3 since ChatGPT excels at filtering
+
+### CHATGPT_USE_QDF
+
+Enables Query Deserves Freshness time-based scoring.
+
+```toml
+CHATGPT_USE_QDF = "false"  # Default: false
+```
+
+When enabled and ChatGPT sends `--QDF=X` hints:
+- **QDF=5**: Boosts notes from last 30 days by 15%
+- **QDF=4**: Boosts notes from last 60 days by 10%
+- **QDF=3**: Boosts notes from last 90 days by 5%
+- **QDF=0-2**: No boost applied
+
+**When to enable:**
+- Your vault contains time-sensitive content (meeting notes, daily journals)
+- You frequently search for recent information
+- You want ChatGPT to prioritize newer content
+
+**When to keep disabled (default):**
+- Your vault contains evergreen content (documentation, guides)
+- Older notes are often more valuable than recent ones
+- You prefer pure semantic similarity without time bias
+
+## Query Deserves Freshness (QDF)
+
+### What is QDF?
+
+QDF is a search ranking concept where certain queries benefit from fresher results. ChatGPT automatically adds `--QDF=X` parameters to queries it considers time-sensitive.
+
+### QDF Scale
+
+| QDF Value | Intent | Time Window | Boost Factor |
+|-----------|--------|-------------|--------------|
+| 0 | Historical/unchanging | No boost | 1.0x |
+| 1 | General information | No boost | 1.0x |
+| 2 | Slow-changing | No boost | 1.0x |
+| 3 | Moderately fresh | 90 days | 1.05x |
+| 4 | Recent/fast-moving | 60 days | 1.10x |
+| 5 | Latest/breaking | 30 days | 1.15x |
+
+### Implementation Details
+
+When QDF is detected:
+1. The `--QDF=X` parameter is stripped from the query
+2. The cleaned query is used for embedding generation
+3. If `CHATGPT_USE_QDF="true"` and QDF ≥ 3:
+   - Notes modified within the time window get a score boost
+   - Results are re-sorted by boosted scores
+4. If `CHATGPT_USE_QDF="false"` (default):
+   - QDF is logged but ignored
+   - No time-based scoring is applied
+
+## Tool Specifications
+
+### search Tool
+
+ChatGPT expects exactly this interface:
+
+```typescript
+{
+  name: "search",
+  description: "Search for documents in Obsidian vault",
+  parameters: {
+    query: string  // The only parameter ChatGPT can provide
+  },
+  returns: {
+    results: Array<{
+      id: string,      // Note path
+      title: string,   // Note title
+      text: string,    // Preview text (200 chars)
+      url: string      // Obsidian URL
+    }>
+  }
+}
+```
+
+### fetch Tool
+
+```typescript
+{
+  name: "fetch",
+  description: "Retrieve complete document content by ID",
+  parameters: {
+    id: string  // Document path
+  },
+  returns: {
+    id: string,
+    title: string,
+    text: string,      // Full content
+    url: string,
+    metadata: {        // Optional metadata
+      tags: string[],
+      createdAt: string,
+      modifiedAt: string,
+      path: string
+    }
+  }
+}
+```
+
+## Compatibility
+
+### Supported ChatGPT Modes
+
+The connector works in any ChatGPT mode where Connectors can be selected:
+- GPT-5 Auto
+- GPT-5 Fast
+- GPT-5 Thinking mini
+- GPT-5 Thinking
+- Legacy models (where Connectors are available)
+
+### Not Available In
+
+- **GPT-5 Pro**: This mode doesn't currently support Connectors
+
+## Migration Notes
+
+### For Existing v1 Users
+
+If you already have obvec deployed with the v1 migration:
+1. Use `wrangler.toml.upgrade` instead of `wrangler.toml.example`
+2. The v2 migration only adds `ChatGPTMCP` (not `ObsidianVectorizeMCP`)
+3. This avoids Durable Object re-declaration conflicts
+
+### For New Users
+
+Use `wrangler.toml.example` which includes both Durable Objects in the v2 migration.
+
+## Troubleshooting
+
+### ChatGPT finds no results
+
+1. Check the minimum score threshold:
+   ```toml
+   CHATGPT_MIN_SCORE = "0.2"  # Try lowering if too restrictive
+   ```
+
+2. Verify your vault has been indexed:
+   ```bash
+   obvec stats
+   ```
+
+3. Monitor logs during search:
+   ```bash
+   npx wrangler tail --format pretty
+   ```
+
+### QDF not working as expected
+
+1. Verify QDF is enabled:
+   ```toml
+   CHATGPT_USE_QDF = "true"
+   ```
+
+2. Check that your notes have `modifiedAt` metadata
+
+3. Look for QDF logs:
+   ```
+   Query includes QDF=5 (freshness hint)
+   Applying QDF=5 freshness boost for notes modified in last 30 days
+   ```
+
+### Authentication issues
+
+1. Ensure `MCP_PASSWORD` is set:
+   ```bash
+   wrangler secret put MCP_PASSWORD
+   ```
+
+2. Try re-adding the connector in ChatGPT
+
+3. Check OAuth logs for errors
+
+## Advanced Usage
+
+### Combining with Other Connectors
+
+ChatGPT can use multiple connectors simultaneously. Your Obsidian vault can complement:
+- Gmail for email search
+- Google Drive for document search
+- Web browsing for current information
+
+### Deep Research Integration
+
+When ChatGPT performs deep research, it automatically includes your Obsidian vault as a knowledge source alongside web search results.
+
+### Custom Vault Names
+
+Set your vault name for proper Obsidian URL generation:
+```toml
+OBSIDIAN_VAULT_NAME = "MyKnowledgeBase"
+```
+
+This ensures generated URLs open correctly in Obsidian.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obvec",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obvec",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "^0.0.5",
@@ -73,13 +73,13 @@
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.5.0.tgz",
-      "integrity": "sha512-CZe9B2VbjIQjBTyc+KoZcN1oUcm4T6GgCXoel9O7647djHuSRAa6sM6G+NdxWArATZgeMMbsvn9C50GCcnIatA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.6.1.tgz",
+      "integrity": "sha512-48rC6jo9CkSRkImfu5KU4zKyoPJx7b9GTUpZn0Emr6J+jkmrLhwCY3BI10QS+fhOt1NkJNlxIcYrBgvWeCpKOw==",
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.19",
-        "workerd": "^1.20250722.0"
+        "workerd": "^1.20250802.0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -88,9 +88,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250730.0.tgz",
-      "integrity": "sha512-X3egNyTjLQaECYe34x8Al7r4oXAhcN3a8+8qcpNCcq1sgtuHIeAwS9potgRR/mwkGfmrJn7nfAyDKC4vrkniQQ==",
+      "version": "1.20250813.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250813.0.tgz",
+      "integrity": "sha512-Pka37/jqLy7ZaQlwpBy79A/BLH+qpRPSEX2h/zWND+qRfoCVCCaZQPdknHZO0pcvHPzK8E2Z4j5QI1IafPA5UA==",
       "cpu": [
         "x64"
       ],
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250730.0.tgz",
-      "integrity": "sha512-/4bvcaGY/9v0rghgKboGiyPKKGQTbDnQ1EeY0oN0SSQH0Cp3OBzqwni/JRvh8TEaD+5azJnSFLlFZj9w7fo+hw==",
+      "version": "1.20250813.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250813.0.tgz",
+      "integrity": "sha512-QnaJbmhcA32+4uZ+or1hXZjdxGqrFUuh6Ye+skEGu3iB/xzq9CmyVyoKoshiUOcWGKndQb7KRo56dq0bVvVLFw==",
       "cpu": [
         "arm64"
       ],
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250730.0.tgz",
-      "integrity": "sha512-I4ZsXYdNkqkJnzNFKADMufiLIzRdIRsN7dSH8UCPw2fYp1BbKA10AkKVqitFwBxIY8eOzQ6Vf7c41AjLQmtJqA==",
+      "version": "1.20250813.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250813.0.tgz",
+      "integrity": "sha512-6pokgBQmujJsAuqOme2wBX5ol/1YW3d7kV7wp0Y1/tFi46TnmWcEy08B4FD5t2AARQJ68a7XMxIJKWChcaJ9Cg==",
       "cpu": [
         "x64"
       ],
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250730.0.tgz",
-      "integrity": "sha512-tTpO6139jFQ5vxgtBZgS8Y8R1jVidS4n7s37x5xO9bCWLZoL0kTj38UGZ8FENkTeaMxE9Mm//nbQol7TfJ2nZg==",
+      "version": "1.20250813.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250813.0.tgz",
+      "integrity": "sha512-lFwqohi8fkR98OwjHT69sbThx4BJem7vu6N8kqrge7wuKJWrMDNbzOTdyBA8adV9DmE07ELuN2vcbbu8ZjaL2Q==",
       "cpu": [
         "arm64"
       ],
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250730.0.tgz",
-      "integrity": "sha512-paVHgocuilMzOU+gEyKR/86j/yI+QzmSHRnqdd8OdQ37Hf6SyPX7kQj6VVNRXbzVHWix1WxaJsXfTGK1LK05wA==",
+      "version": "1.20250813.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250813.0.tgz",
+      "integrity": "sha512-Fs62NvUajtoXb+4W8jaRXzw64Nbmb8X+PbRLZbxUFv68sGhxKPw1nB1YEmNNZ215ma47hTlSdF3UQh4FOmz7NA==",
       "cpu": [
         "x64"
       ],
@@ -177,9 +177,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20250802.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250802.0.tgz",
-      "integrity": "sha512-zWjDMBxPf4kv4air928Qpo1fmIacMKbztO4R3+fdrB2stn0425zJrqhRGye27e/v9cA1Jum8IHl7Q/P2ZIT2QA==",
+      "version": "4.20250816.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250816.0.tgz",
+      "integrity": "sha512-R9ADrrINo1CqTwCddH39Tjlsc3grim6KeO7l8yddNbldH3uTkaAXYCzO0WiyLG7irLzLDrZVc4tLhN6BO3tdFw==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -975,9 +975,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2162,9 +2162,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20250730.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250730.0.tgz",
-      "integrity": "sha512-avGXBStHQSqcJr8ra1mJ3/OQvnLZ49B1uAILQapAha1DHNZZvXWLIgUVre/WGY6ZOlNGFPh5CJ+dXLm4yuV3Jw==",
+      "version": "4.20250813.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250813.1.tgz",
+      "integrity": "sha512-6PyXwR4pZmH9ukO0jR5LmhlFVMktsVVGVcUjD9Lpev5QwnqjTRPEv73cnXCe0+oTbIm5TYnvXsAklaWxQuxstA==",
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -2175,7 +2175,7 @@
         "sharp": "^0.33.5",
         "stoppable": "1.1.0",
         "undici": "^7.10.0",
-        "workerd": "1.20250730.0",
+        "workerd": "1.20250813.0",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10",
         "zod": "3.22.3"
@@ -2691,9 +2691,9 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.0.0.tgz",
-      "integrity": "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.1.0.tgz",
+      "integrity": "sha512-GBuewsPrhJPftT+fqDa9oI/zc5HNsG9nREqwzoSFDOIqf0NggOZbHQj2TE1P1CDJK8ZogFnlZY9hWoUiur7I/A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2878,9 +2878,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250730.0.tgz",
-      "integrity": "sha512-w6e0WM2YGfYQGmg0dewZeLUYIxAzMYK1R31vaS4HHHjgT32Xqj0eVQH+leegzY51RZPNCvw5pe8DFmW4MGf8Fg==",
+      "version": "1.20250813.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250813.0.tgz",
+      "integrity": "sha512-bDlPGSnb/KESpGFE57cDjgP8mEKDM4WBTd/uGJBsQYCB6Aokk1eK3ivtHoxFx3MfJNo3v6/hJy6KK1b6rw1gvg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2890,27 +2890,27 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20250730.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20250730.0",
-        "@cloudflare/workerd-linux-64": "1.20250730.0",
-        "@cloudflare/workerd-linux-arm64": "1.20250730.0",
-        "@cloudflare/workerd-windows-64": "1.20250730.0"
+        "@cloudflare/workerd-darwin-64": "1.20250813.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250813.0",
+        "@cloudflare/workerd-linux-64": "1.20250813.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250813.0",
+        "@cloudflare/workerd-windows-64": "1.20250813.0"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.27.0.tgz",
-      "integrity": "sha512-YNHZyMNWebFt9jD6dc20tQrCmnSzJj3SoB0FFa90w11Cx4lbP3d+rUZYjb18Zt+OGSMay1wT2PzwT2vCTskkmg==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.30.0.tgz",
+      "integrity": "sha512-NXJUObuXxgG8/ChQ4yXkWLmDQ5ZcO98gyq1yFKYVntJ884C0IpDQrVnAv2RA0ZEz5eB8zal+4OKnr26P3N7ItA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.0",
-        "@cloudflare/unenv-preset": "2.5.0",
+        "@cloudflare/unenv-preset": "2.6.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.25.4",
-        "miniflare": "4.20250730.0",
+        "miniflare": "4.20250813.1",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.19",
-        "workerd": "1.20250730.0"
+        "workerd": "1.20250813.0"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -2923,7 +2923,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20250730.0"
+        "@cloudflare/workers-types": "^4.20250813.0"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obvec",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "AI-powered Obsidian knowledge base with Cloudflare Vectorize and MCP support. Transform your Obsidian vault into a searchable, AI-accessible knowledge base using serverless Cloudflare Workers.",
   "main": "src/index.ts",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,12 +21,16 @@ export default {
     const oauthProvider = new OAuthProvider({
       apiHandlers: {
         // Standard MCP endpoints (full Obsidian tools)
-        '/sse': ObsidianVectorizeMCP.serveSSE('/sse'),
-        '/mcp': ObsidianVectorizeMCP.serve('/mcp'),
+        '/sse': ObsidianVectorizeMCP.serveSSE('/sse', { binding: 'MCP_OBJECT' }),
+        '/sse/': ObsidianVectorizeMCP.serveSSE('/sse', { binding: 'MCP_OBJECT' }),
+        '/mcp': ObsidianVectorizeMCP.serve('/mcp', { binding: 'MCP_OBJECT' }),
+        '/mcp/': ObsidianVectorizeMCP.serve('/mcp', { binding: 'MCP_OBJECT' }),
         
         // ChatGPT-specific endpoints (search/fetch only)
-        '/chatgpt/sse': ChatGPTMCP.serveSSE('/chatgpt/sse'),
-        '/chatgpt/mcp': ChatGPTMCP.serve('/chatgpt/mcp'),
+        '/chatgpt/sse': ChatGPTMCP.serveSSE('/chatgpt/sse', { binding: 'CHATGPT_MCP_OBJECT' }),
+        '/chatgpt/sse/': ChatGPTMCP.serveSSE('/chatgpt/sse', { binding: 'CHATGPT_MCP_OBJECT' }),
+        '/chatgpt/mcp': ChatGPTMCP.serve('/chatgpt/mcp', { binding: 'CHATGPT_MCP_OBJECT' }),
+        '/chatgpt/mcp/': ChatGPTMCP.serve('/chatgpt/mcp', { binding: 'CHATGPT_MCP_OBJECT' }),
       },
       defaultHandler: app as any,
       authorizeEndpoint: "/authorize",

--- a/src/mcp/server-chatgpt.ts
+++ b/src/mcp/server-chatgpt.ts
@@ -1,0 +1,177 @@
+import { McpAgent } from "agents/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { Env, State } from '../types';
+import { generateEmbedding } from '../utils/embeddings';
+
+function registerChatGPTTools(agent: ChatGPTMCP, env: Env) {
+  const vectorize = env.VECTORIZE;
+  
+  // Tool 1: Search (ChatGPT-required)
+  agent.server.tool(
+    "search",
+    "Search for documents in Obsidian vault",
+    {
+      query: z.string().describe("Search query string")
+    },
+    async ({ query }) => {
+      try {
+        // Generate embedding
+        const queryEmbedding = await generateEmbedding(query, env);
+        
+        // Search vectorize
+        const results = await vectorize.query(queryEmbedding, {
+          topK: 10,
+          returnMetadata: true
+        });
+        
+        // Transform to ChatGPT format
+        const searchResults = results.matches
+          .filter(match => match.score >= 0.5)
+          .map(match => {
+            const metadata = match.metadata as any;
+            const vaultName = env.OBSIDIAN_VAULT_NAME || 'ObsidianVault';
+            
+            return {
+              id: metadata.path,
+              title: metadata.title || metadata.path.split('/').pop()?.replace('.md', '') || 'Untitled',
+              text: metadata.content ? 
+                metadata.content.substring(0, 200) + (metadata.content.length > 200 ? '...' : '') : 
+                'No preview available',
+              url: `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(metadata.path)}`
+            };
+          });
+        
+        // Return as JSON string in MCP content wrapper
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({ results: searchResults }, null, 2)
+          }]
+        };
+      } catch (error: any) {
+        console.error('ChatGPT search error:', error);
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({ 
+              results: [], 
+              error: `Search failed: ${error.message}` 
+            }, null, 2)
+          }]
+        };
+      }
+    }
+  );
+  
+  // Tool 2: Fetch (ChatGPT-required)
+  agent.server.tool(
+    "fetch",
+    "Retrieve complete document content by ID",
+    {
+      id: z.string().describe("Document ID (note path)")
+    },
+    async ({ id }) => {
+      try {
+        // Fetch from R2
+        const r2Key = `notes/${id}`;
+        const r2Object = await env.R2.get(r2Key);
+        
+        if (!r2Object) {
+          throw new Error(`Document not found: ${id}`);
+        }
+        
+        const noteData = await r2Object.json() as any;
+        const vaultName = env.OBSIDIAN_VAULT_NAME || 'ObsidianVault';
+        
+        // Return as JSON string in MCP content wrapper
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              id: id,
+              title: noteData.title || id.split('/').pop()?.replace('.md', '') || 'Untitled',
+              text: noteData.content || '',
+              url: `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(id)}`,
+              metadata: {
+                tags: noteData.tags || [],
+                createdAt: noteData.createdAt,
+                modifiedAt: noteData.modifiedAt,
+                path: id
+              }
+            }, null, 2)
+          }]
+        };
+      } catch (error: any) {
+        console.error('ChatGPT fetch error:', error);
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              id: id,
+              title: 'Error',
+              text: `Failed to retrieve document: ${error.message}`,
+              url: '',
+              metadata: null
+            }, null, 2)
+          }]
+        };
+      }
+    }
+  );
+}
+
+export class ChatGPTMCP extends McpAgent<Env, State, {}> {
+  server = new McpServer({ 
+    name: "obvec-chatgpt",
+    version: "0.1.0",
+    title: "Obsidian Notes for ChatGPT"
+  }, {
+    instructions: `This MCP server provides ChatGPT-compatible search and fetch tools for Obsidian notes.
+    
+It implements the exact specification required by ChatGPT connectors:
+- search: Accepts a query string, returns search results as JSON
+- fetch: Accepts a document ID (note path), returns full content as JSON
+
+Responses are formatted as JSON strings for ChatGPT compatibility.
+The server accesses your indexed Obsidian vault through Cloudflare Vectorize for semantic search.`
+  });
+
+  override initialState: State = { 
+    searchCount: 0 
+  };
+
+  constructor(
+    public override ctx: DurableObjectState,
+    public override env: Env
+  ) {
+    super(ctx, env);
+  }
+
+  async init() {
+    registerChatGPTTools(this, this.env);
+  }
+
+  override onStateUpdate(state: State) {
+    console.log('ChatGPT MCP Agent state updated:', state);
+  }
+}
+
+// Create the API handler for ChatGPT endpoints
+export default {
+  fetch: (req: Request, env: unknown, ctx: ExecutionContext) => {
+    const url = new URL(req.url);
+    
+    // ChatGPT SSE endpoints (deprecated but supported)
+    if (url.pathname === '/chatgpt/sse' || url.pathname === '/chatgpt/sse/message') {
+      return ChatGPTMCP.serveSSE('/chatgpt/sse').fetch(req, env, ctx);
+    }
+    
+    // ChatGPT Streamable HTTP endpoint (recommended)
+    if (url.pathname === '/chatgpt/mcp') {
+      return ChatGPTMCP.serve('/chatgpt/mcp').fetch(req, env, ctx);
+    }
+    
+    return new Response('Not found', { status: 404 });
+  },
+};

--- a/src/mcp/server-chatgpt.ts
+++ b/src/mcp/server-chatgpt.ts
@@ -8,6 +8,8 @@ function registerChatGPTTools(agent: ChatGPTMCP, env: Env) {
   const vectorize = env.VECTORIZE;
   
   // Tool 1: Search (ChatGPT-required)
+  // ChatGPT expects the search tool to accept a single "query" string parameter
+  // and return an object with a "results" array containing objects with id, title, text, url
   agent.server.tool(
     "search",
     "Search for documents in Obsidian vault",
@@ -15,19 +17,70 @@ function registerChatGPTTools(agent: ChatGPTMCP, env: Env) {
       query: z.string().describe("Search query string")
     },
     async ({ query }) => {
+      console.log(`ChatGPT search requested for query: "${query}"`);
+      
+      // Parse QDF (Query Deserves Freshness) parameter if present
+      const qdfMatch = query.match(/--QDF=(\d)/);
+      const qdf = qdfMatch ? parseInt(qdfMatch[1], 10) : null;
+      const cleanQuery = query.replace(/--QDF=\d/, '').trim();
+      
+      if (qdf !== null) {
+        console.log(`Query includes QDF=${qdf} (freshness hint)`);
+      }
+      
+      // Check if QDF support is enabled
+      const useQDF = env.CHATGPT_USE_QDF === 'true';
+      
       try {
-        // Generate embedding
-        const queryEmbedding = await generateEmbedding(query, env);
+        // Generate embedding using cleaned query
+        const queryEmbedding = await generateEmbedding(cleanQuery, env);
+        console.log(`Generated embedding for query, dimensions: ${queryEmbedding.length}`);
         
         // Search vectorize
         const results = await vectorize.query(queryEmbedding, {
           topK: 10,
           returnMetadata: true
         });
+        console.log(`Vectorize returned ${results.matches.length} matches`);
         
-        // Transform to ChatGPT format
-        const searchResults = results.matches
-          .filter(match => match.score >= 0.5)
+        // Get minimum score threshold from environment or use default
+        const minScore = env.CHATGPT_MIN_SCORE ? parseFloat(env.CHATGPT_MIN_SCORE) : 0.3;
+        console.log(`Using minimum score threshold: ${minScore}`);
+        
+        // Log all scores for debugging
+        console.log('All match scores:', results.matches.map(m => ({
+          path: (m.metadata as any).path,
+          score: m.score
+        })));
+        
+        // Apply QDF time-based scoring if enabled and QDF is present
+        let processedResults = results.matches;
+        
+        if (useQDF && qdf !== null && qdf >= 3) {
+          // Only apply freshness boost for QDF 3+ (moderately fresh to very fresh)
+          // QDF scale: 3 = 90 days, 4 = 60 days, 5 = 30 days
+          const daysCutoff = qdf === 5 ? 30 : qdf === 4 ? 60 : 90;
+          const cutoffDate = new Date(Date.now() - daysCutoff * 24 * 60 * 60 * 1000);
+          
+          console.log(`Applying QDF=${qdf} freshness boost for notes modified in last ${daysCutoff} days`);
+          
+          processedResults = processedResults.map(match => {
+            const metadata = match.metadata as any;
+            if (metadata.modifiedAt) {
+              const modifiedDate = new Date(metadata.modifiedAt);
+              if (modifiedDate > cutoffDate) {
+                // Boost recent notes by 10-20% based on QDF level
+                const boostFactor = 1 + (0.05 * (qdf - 2)); // QDF=3: 1.05, QDF=4: 1.10, QDF=5: 1.15
+                return { ...match, score: Math.min(1.0, match.score * boostFactor) };
+              }
+            }
+            return match;
+          }).sort((a, b) => b.score - a.score);
+        }
+        
+        // Transform to ChatGPT format - each result must have: id, title, text, url
+        const searchResults = processedResults
+          .filter(match => match.score >= minScore)
           .map(match => {
             const metadata = match.metadata as any;
             const vaultName = env.OBSIDIAN_VAULT_NAME || 'ObsidianVault';
@@ -42,22 +95,28 @@ function registerChatGPTTools(agent: ChatGPTMCP, env: Env) {
             };
           });
         
-        // Return as JSON string in MCP content wrapper
+        // ChatGPT expects a plain JSON object with a "results" array
+        const response = { results: searchResults };
+        
+        // Return as text content with JSON string for MCP protocol compatibility
         return {
           content: [{
             type: "text" as const,
-            text: JSON.stringify({ results: searchResults }, null, 2)
+            text: JSON.stringify(response, null, 2)
           }]
         };
       } catch (error: any) {
         console.error('ChatGPT search error:', error);
+        
+        const errorResponse = { 
+          results: [], 
+          error: `Search failed: ${error.message}` 
+        };
+        
         return {
           content: [{
             type: "text" as const,
-            text: JSON.stringify({ 
-              results: [], 
-              error: `Search failed: ${error.message}` 
-            }, null, 2)
+            text: JSON.stringify(errorResponse, null, 2)
           }]
         };
       }
@@ -65,6 +124,8 @@ function registerChatGPTTools(agent: ChatGPTMCP, env: Env) {
   );
   
   // Tool 2: Fetch (ChatGPT-required)
+  // ChatGPT expects the fetch tool to accept a single "id" string parameter
+  // and return a single object with id, title, text, url, and optional metadata
   agent.server.tool(
     "fetch",
     "Retrieve complete document content by ID",
@@ -84,36 +145,42 @@ function registerChatGPTTools(agent: ChatGPTMCP, env: Env) {
         const noteData = await r2Object.json() as any;
         const vaultName = env.OBSIDIAN_VAULT_NAME || 'ObsidianVault';
         
-        // Return as JSON string in MCP content wrapper
+        // ChatGPT expects a single document object with id, title, text, url, and optional metadata
+        const response = {
+          id: id,
+          title: noteData.title || id.split('/').pop()?.replace('.md', '') || 'Untitled',
+          text: noteData.content || '',
+          url: `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(id)}`,
+          metadata: {
+            tags: noteData.tags || [],
+            createdAt: noteData.createdAt,
+            modifiedAt: noteData.modifiedAt,
+            path: id
+          }
+        };
+        
+        // Return as text content with JSON string for MCP protocol compatibility
         return {
           content: [{
             type: "text" as const,
-            text: JSON.stringify({
-              id: id,
-              title: noteData.title || id.split('/').pop()?.replace('.md', '') || 'Untitled',
-              text: noteData.content || '',
-              url: `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(id)}`,
-              metadata: {
-                tags: noteData.tags || [],
-                createdAt: noteData.createdAt,
-                modifiedAt: noteData.modifiedAt,
-                path: id
-              }
-            }, null, 2)
+            text: JSON.stringify(response, null, 2)
           }]
         };
       } catch (error: any) {
         console.error('ChatGPT fetch error:', error);
+        
+        const errorResponse = {
+          id: id,
+          title: 'Error',
+          text: `Failed to retrieve document: ${error.message}`,
+          url: '',
+          metadata: null
+        };
+        
         return {
           content: [{
             type: "text" as const,
-            text: JSON.stringify({
-              id: id,
-              title: 'Error',
-              text: `Failed to retrieve document: ${error.message}`,
-              url: '',
-              metadata: null
-            }, null, 2)
+            text: JSON.stringify(errorResponse, null, 2)
           }]
         };
       }
@@ -122,21 +189,8 @@ function registerChatGPTTools(agent: ChatGPTMCP, env: Env) {
 }
 
 export class ChatGPTMCP extends McpAgent<Env, State, {}> {
-  server = new McpServer({ 
-    name: "obvec-chatgpt",
-    version: "0.1.0",
-    title: "Obsidian Notes for ChatGPT"
-  }, {
-    instructions: `This MCP server provides ChatGPT-compatible search and fetch tools for Obsidian notes.
-    
-It implements the exact specification required by ChatGPT connectors:
-- search: Accepts a query string, returns search results as JSON
-- fetch: Accepts a document ID (note path), returns full content as JSON
-
-Responses are formatted as JSON strings for ChatGPT compatibility.
-The server accesses your indexed Obsidian vault through Cloudflare Vectorize for semantic search.`
-  });
-
+  private mcpServer: McpServer;
+  
   override initialState: State = { 
     searchCount: 0 
   };
@@ -146,6 +200,35 @@ The server accesses your indexed Obsidian vault through Cloudflare Vectorize for
     public override env: Env
   ) {
     super(ctx, env);
+    
+    // Initialize the MCP server
+    this.mcpServer = new McpServer({ 
+      name: "obvec-chatgpt",
+      version: "0.1.0",
+      title: "Obsidian Notes for ChatGPT"
+    }, {
+      instructions: `This MCP server provides ChatGPT-compatible search and fetch tools for Obsidian notes.
+
+It implements the exact OpenAI specification required by ChatGPT connectors:
+
+SEARCH TOOL:
+- Accepts: single "query" string parameter
+- Returns: object with "results" array containing {id, title, text, url} objects
+- Purpose: Find relevant documents matching the search query
+
+FETCH TOOL:
+- Accepts: single "id" string parameter (document path)
+- Returns: single object with {id, title, text, url, metadata} structure
+- Purpose: Retrieve complete content of a specific document
+
+The server uses Cloudflare Vectorize for semantic search across your indexed Obsidian vault.
+All responses follow the exact JSON format expected by ChatGPT connectors.`
+    });
+  }
+  
+  // Implement the abstract server property
+  get server(): McpServer {
+    return this.mcpServer;
   }
 
   async init() {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,10 +13,13 @@ export interface Env {
   R2: R2Bucket;
   OAUTH_KV: KVNamespace; // Required for OAuth Provider Library
   MCP_OBJECT: DurableObjectNamespace; // MCP Durable Object
+  CHATGPT_MCP_OBJECT: DurableObjectNamespace; // ChatGPT-specific MCP Durable Object
   EMBEDDING_MODEL?: string;
   EMBEDDING_DIMENSIONS?: string;
   // Simple Authentication (for mock auth flow)
   MCP_PASSWORD?: string; // Set via wrangler secret put MCP_PASSWORD
+  // Obsidian configuration
+  OBSIDIAN_VAULT_NAME?: string; // Name of the Obsidian vault for URL generation
 }
 
 export type State = { 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,9 @@ export interface Env {
   MCP_PASSWORD?: string; // Set via wrangler secret put MCP_PASSWORD
   // Obsidian configuration
   OBSIDIAN_VAULT_NAME?: string; // Name of the Obsidian vault for URL generation
+  // ChatGPT configuration
+  CHATGPT_MIN_SCORE?: string; // Minimum score threshold for ChatGPT search results (default: 0.3)
+  CHATGPT_USE_QDF?: string; // Enable Query Deserves Freshness time-based scoring (true/false, default: false)
 }
 
 export type State = { 

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -24,6 +24,12 @@ EMBEDDING_MODEL = "@cf/baai/bge-large-en-v1.5"
 EMBEDDING_DIMENSIONS = "1024"
 # Optional: Set your Obsidian vault name for proper URL generation in ChatGPT
 # OBSIDIAN_VAULT_NAME = "YourVaultName"
+# Optional: Minimum score threshold for ChatGPT search results (0.0-1.0, default: 0.3)
+# Lower values return more results, higher values return only best matches
+# CHATGPT_MIN_SCORE = "0.3"
+# Optional: Enable Query Deserves Freshness (QDF) time-based scoring (true/false, default: false)
+# When enabled, ChatGPT's freshness hints boost recent notes in search results
+# CHATGPT_USE_QDF = "false"
 
 # Authentication Configuration
 # Set your MCP password using: wrangler secret put MCP_PASSWORD

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -3,18 +3,27 @@ main = "src/index.ts"
 compatibility_date = "2025-07-30"
 compatibility_flags = ["nodejs_compat"]
 
+# Standard MCP Durable Object
 [[durable_objects.bindings]]
 name = "MCP_OBJECT"
 class_name = "ObsidianVectorizeMCP"
 script_name = "obvec"
 
+# ChatGPT-specific Durable Object
+[[durable_objects.bindings]]
+name = "CHATGPT_MCP_OBJECT"
+class_name = "ChatGPTMCP"
+script_name = "obvec"
+
 [[migrations]]
-tag = "v1"
-new_sqlite_classes = ["ObsidianVectorizeMCP"]
+tag = "v2"
+new_sqlite_classes = ["ObsidianVectorizeMCP", "ChatGPTMCP"]
 
 [vars]
 EMBEDDING_MODEL = "@cf/baai/bge-large-en-v1.5"
 EMBEDDING_DIMENSIONS = "1024"
+# Optional: Set your Obsidian vault name for proper URL generation in ChatGPT
+# OBSIDIAN_VAULT_NAME = "YourVaultName"
 
 # Authentication Configuration
 # Set your MCP password using: wrangler secret put MCP_PASSWORD

--- a/wrangler.toml.upgrade
+++ b/wrangler.toml.upgrade
@@ -1,0 +1,65 @@
+# Upgrade configuration for existing v1 deployments
+# Use this file if you already have ObsidianVectorizeMCP deployed with v1 migration
+# Copy this to wrangler.toml: cp wrangler.toml.upgrade wrangler.toml
+
+name = "obvec"
+main = "src/index.ts"
+compatibility_date = "2025-07-30"
+compatibility_flags = ["nodejs_compat"]
+
+# Standard MCP Durable Object (already exists from v1)
+[[durable_objects.bindings]]
+name = "MCP_OBJECT"
+class_name = "ObsidianVectorizeMCP"
+script_name = "obvec"
+
+# ChatGPT-specific Durable Object (new in v2)
+[[durable_objects.bindings]]
+name = "CHATGPT_MCP_OBJECT"
+class_name = "ChatGPTMCP"
+script_name = "obvec"
+
+# Migration v2 only adds ChatGPTMCP since ObsidianVectorizeMCP already exists
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["ChatGPTMCP"]
+
+[vars]
+EMBEDDING_MODEL = "@cf/baai/bge-large-en-v1.5"
+EMBEDDING_DIMENSIONS = "1024"
+# Set your Obsidian vault name for proper URL generation in ChatGPT
+OBSIDIAN_VAULT_NAME = "YourVaultName"
+# Minimum score threshold for ChatGPT search results (0.0-1.0, default: 0.3)
+# Lower values return more results, higher values return only best matches
+CHATGPT_MIN_SCORE = "0.3"
+# Enable Query Deserves Freshness (QDF) time-based scoring (true/false, default: false)
+# When enabled, ChatGPT's freshness hints boost recent notes in search results
+CHATGPT_USE_QDF = "false"
+
+# Authentication Configuration
+# Set your MCP password using: wrangler secret put MCP_PASSWORD
+
+[ai]
+binding = "AI"
+
+[[vectorize]]
+binding = "VECTORIZE"
+index_name = "obsidian-notes"
+
+# KV namespace for general storage
+# Use your existing KV namespace ID from v1 deployment
+[[kv_namespaces]]
+binding = "KV"
+id = "YOUR_EXISTING_KV_NAMESPACE_ID"
+
+# KV namespace for OAuth tokens
+# Use your existing OAuth KV namespace ID from v1 deployment
+[[kv_namespaces]]
+binding = "OAUTH_KV"
+id = "YOUR_EXISTING_OAUTH_KV_NAMESPACE_ID"
+
+# R2 bucket for note content and metadata
+# Use your existing R2 bucket from v1 deployment
+[[r2_buckets]]
+binding = "R2"
+bucket_name = "YOUR_EXISTING_R2_BUCKET"


### PR DESCRIPTION
## Summary

This PR adds full ChatGPT integration to the Obsidian Vectorize MCP server, enabling ChatGPT users to search and retrieve content from their Obsidian vaults through ChatGPT's Connector interface.

## Key Features

### 🎯 Dedicated ChatGPT Endpoints
- New `/chatgpt/mcp` endpoint for Streamable HTTP transport (recommended)
- Legacy `/chatgpt/sse` endpoint for SSE fallback
- Separate Durable Object (`ChatGPTMCP`) ensures clean separation from standard MCP implementation

### 🔧 Configurable Search Parameters
- **`CHATGPT_MIN_SCORE`**: Adjustable similarity threshold (default: 0.3)
  - Lowered from initial 0.5 to ensure relevant results aren't filtered out
  - Configurable via `wrangler.toml` for user preference
- **`CHATGPT_USE_QDF`**: Optional Query Deserves Freshness support (default: false)
  - Automatically detects ChatGPT's `--QDF=X` freshness hints
  - When enabled, boosts recent notes based on time sensitivity
  - Disabled by default since most Obsidian content is evergreen

### 📊 Query Deserves Freshness (QDF) Implementation
ChatGPT automatically adds QDF parameters to time-sensitive queries. When enabled:
- QDF=5: Boosts notes from last 30 days by 15%
- QDF=4: Boosts notes from last 60 days by 10%
- QDF=3: Boosts notes from last 90 days by 5%
- QDF 0-2: No boost applied

### 📚 Comprehensive Documentation
- Created `docs/chatgpt-integration.md` with full integration guide
- Simplified README to focus on quick start
- Added migration path for existing v1 deployments via `wrangler.toml.upgrade`

## Technical Implementation

### Tool Interface
ChatGPT requires specific tool names with simplified parameters:
```typescript
search(query: string) → { results: Array<{id, title, text, url}> }
fetch(id: string) → { id, title, text, url, metadata }
```

### Response Format
- All responses use `type: "text"` with JSON.stringify for MCP protocol compatibility
- ChatGPT cannot specify advanced parameters (minScore, tags, etc.)
- Maximum 10 results returned for ChatGPT to intelligently filter

### Migration Support
- New users: Use `wrangler.toml.example` with both Durable Objects
- Existing v1 users: Use `wrangler.toml.upgrade` to avoid re-declaration conflicts

## Testing

✅ Tested with:
- ChatGPT web interface using Streamable HTTP endpoint
- MCP Inspector for validation
- OAuth authentication flow
- Search queries with various score thresholds
- QDF parameter parsing and optional application

## Breaking Changes

None - Full backward compatibility maintained for existing MCP clients.

## Deployment

```bash
# For new installations
cp wrangler.toml.example wrangler.toml
npm run deploy

# For existing v1 deployments
cp wrangler.toml.upgrade wrangler.toml
npm run deploy
```

## Example Usage

1. Add connector in ChatGPT: `https://obvec.<subdomain>.workers.dev/chatgpt/mcp`
2. Authenticate via OAuth
3. Use in any ChatGPT mode where Connectors are supported (except GPT-5 Pro)

## Files Changed

- **New**: `src/mcp/server-chatgpt.ts` - ChatGPT-specific MCP implementation
- **New**: `docs/chatgpt-integration.md` - Comprehensive integration guide
- **New**: `wrangler.toml.upgrade` - Migration config for v1 users
- **Modified**: `src/index.ts` - Added ChatGPT endpoint routing
- **Modified**: `README.md` - Added ChatGPT section with link to detailed docs
- **Modified**: `src/types/index.ts` - Added ChatGPT configuration types
- **Modified**: `wrangler.toml.example` - Added ChatGPT Durable Object config

## Related Issues

Closes #[issue-number] (if applicable)

## Screenshots/Logs

Successfully tested with ChatGPT showing:
- Proper OAuth authentication
- Search returning relevant results with configurable scoring
- QDF parameter detection and optional application
- Clean separation from standard MCP endpoints

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] Tests pass locally
- [x] No breaking changes for existing users
- [x] Migration path provided for v1 deployments