### PR TITLE
fix: Extend OAuth token TTL to prevent frequent re-authentication in Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Breaking this down:
 - `obvec` - The name you want to give the server
 - `https://obvec.<account_subdomain>.workers.dev/mcp` - The URL of your MCP endpoint
 
+> **Note for Claude Code users**: OAuth tokens now default to 30 days to prevent frequent re-authentication. If you still experience timeouts, see [troubleshooting](docs/troubleshooting.md#common-issues).
+
 #### Manual Claude Desktop Configuration (Optional)
 If you prefer to configure Claude Desktop directly instead of using Connectors, add to your `claude_desktop_config.json`:
 ```json

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,24 +2,47 @@
 
 ## Common Issues
 
-**1. "OAUTH_KV binding not found"**
+**1. Frequent Re-authentication in Claude Code (CLI)**
+
+**Problem**: Claude Code prompts for re-authentication frequently (e.g., daily).
+
+**Root Cause**: The default OAuth access token expires after 1 hour. Unlike web browsers (claude.ai, ChatGPT), Claude Code doesn't automatically handle token refresh.
+
+**Solution**: The codebase now defaults to 30-day tokens. To adjust further:
+
+```toml
+# In wrangler.toml, add or adjust:
+[vars]
+OAUTH_ACCESS_TOKEN_TTL = "2592000"  # 30 days (default)
+# Or for longer tokens:
+OAUTH_ACCESS_TOKEN_TTL = "7776000"  # 90 days
+```
+
+After updating, redeploy:
+```bash
+obvec deploy
+```
+
+**Note**: This only affects CLI tools like Claude Code. Web clients handle token refresh automatically.
+
+**2. "OAUTH_KV binding not found"**
 ```bash
 wrangler kv:namespace create oauth_tokens
 # Update wrangler.toml with returned namespace ID
 ```
 
-**2. "MCP_PASSWORD not configured"**
+**3. "MCP_PASSWORD not configured"**
 ```bash
 wrangler secret put MCP_PASSWORD
 ```
 
-**3. "OAuth flow not working"**
+**4. "OAuth flow not working"**
 ```bash
 # Test authorization endpoint
 curl "https://your-worker.workers.dev/authorize?client_id=test&redirect_uri=http%3A//localhost&state=123"
 ```
 
-**4. MCP client connection issues**
+**5. MCP client connection issues**
 ```bash
 # Test with MCP Inspector
 npx @modelcontextprotocol/inspector

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obvec",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "AI-powered Obsidian knowledge base with Cloudflare Vectorize and MCP support. Transform your Obsidian vault into a searchable, AI-accessible knowledge base using serverless Cloudflare Workers.",
   "main": "src/index.ts",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,12 @@ export default {
       return handleApiRequest(request, env);
     }
     
+    // Get access token TTL from environment or use default (30 days)
+    // This helps Claude Code which doesn't handle refresh tokens automatically
+    const accessTokenTTL = env.OAUTH_ACCESS_TOKEN_TTL 
+      ? parseInt(env.OAUTH_ACCESS_TOKEN_TTL, 10) 
+      : 30 * 24 * 60 * 60; // Default: 30 days in seconds
+    
     // Create OAuth provider with support for both standard and ChatGPT endpoints
     const oauthProvider = new OAuthProvider({
       apiHandlers: {
@@ -36,6 +42,8 @@ export default {
       authorizeEndpoint: "/authorize",
       tokenEndpoint: "/token",
       clientRegistrationEndpoint: "/register",
+      // Extend access token lifetime from default 1 hour
+      accessTokenTTL,
     });
     
     return oauthProvider.fetch(request, env, ctx);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,8 @@ export interface Env {
   // ChatGPT configuration
   CHATGPT_MIN_SCORE?: string; // Minimum score threshold for ChatGPT search results (default: 0.3)
   CHATGPT_USE_QDF?: string; // Enable Query Deserves Freshness time-based scoring (true/false, default: false)
+  // OAuth configuration
+  OAUTH_ACCESS_TOKEN_TTL?: string; // Access token TTL in seconds (default: 2592000 = 30 days)
 }
 
 export type State = { 

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -30,6 +30,10 @@ EMBEDDING_DIMENSIONS = "1024"
 # Optional: Enable Query Deserves Freshness (QDF) time-based scoring (true/false, default: false)
 # When enabled, ChatGPT's freshness hints boost recent notes in search results
 # CHATGPT_USE_QDF = "false"
+# Optional: OAuth access token TTL in seconds (default: 2592000 = 30 days)
+# Increase this if you're getting frequent re-authentication prompts in Claude Code
+# Note: Web clients (claude.ai, ChatGPT) handle token refresh automatically and don't require this
+# OAUTH_ACCESS_TOKEN_TTL = "2592000"
 
 # Authentication Configuration
 # Set your MCP password using: wrangler secret put MCP_PASSWORD


### PR DESCRIPTION
## Summary
- Extended default OAuth access token TTL from 1 hour to 30 days
- Made TTL configurable via `OAUTH_ACCESS_TOKEN_TTL` environment variable
- Added comprehensive documentation for Claude Code users

## Problem
Claude Code (CLI) was requiring daily re-authentication because:
- Default OAuth access tokens expire after 1 hour
- Unlike web browsers (claude.ai, ChatGPT), Claude Code doesn't automatically handle token refresh
- This created a poor user experience with frequent authentication prompts

## Solution
- Set default `accessTokenTTL` to 30 days (2592000 seconds)
- Allow users to configure longer TTLs if needed (e.g., 90 days)
- Document the issue and solution in troubleshooting guide
- Add note in README for Claude Code users

## Changes
- `src/index.ts`: Added configurable accessTokenTTL with 30-day default
- `src/types/index.ts`: Added OAUTH_ACCESS_TOKEN_TTL to Env interface
- `wrangler.toml.example`: Added configuration documentation
- `docs/troubleshooting.md`: Added detailed explanation as issue #1
- `README.md`: Added note for Claude Code users

## Test Plan
- [ ] Deploy changes with `obvec deploy`
- [ ] Verify Claude Code maintains authentication for >1 day
- [ ] Confirm web clients (claude.ai, ChatGPT) continue working normally
- [ ] Test custom TTL configuration via environment variable